### PR TITLE
Update cs2.json

### DIFF
--- a/pterodactyl/cs2.json
+++ b/pterodactyl/cs2.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-09-26T11:03:39-04:00",
+    "exported_at": "2023-11-12T06:57:40+08:00",
     "name": "Counter-Strike 2 (SteamRT3)",
     "author": "infra@gflclan.com",
     "description": "Counter-Strike is a multiplayer first-person shooter video game developed by Valve. This image is based on Valve's Steam Runtime 3 platform (codenamed SNIPER) and was created to run both CSGO and CS2 without issues.",
@@ -27,7 +27,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\nSTEAM_USER=anonymous\r\nSTEAM_PASS=\"\"\r\nSTEAM_AUTH=\"\"\r\nfi\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${SRCDS_LOGIN} ${SRCDS_LOGIN_PASS} ${STEAM_AUTH} +app_update 730 ${EXTRA_FLAGS} +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so",
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\nSTEAM_USER=anonymous\r\nSTEAM_PASS=\"\"\r\nSTEAM_AUTH=\"\"\r\nfi\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update 730 ${EXTRA_FLAGS} +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so",
             "container": "ghcr.io\/pterodactyl\/installers:debian",
             "entrypoint": "bash"
         }
@@ -81,46 +81,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|numeric",
-            "field_type": "text"
-        },
-        {
-            "name": "SteamCMD Beta Name",
-            "description": "Set the ID of the beta to install and launch. Leave blank to disable Beta loading.",
-            "env_variable": "SRCDS_BETAID",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "max:64",
-            "field_type": "text"
-        },
-        {
-            "name": "SteamCMD Beta Password",
-            "description": "If required, set the password to use to access a Beta depot. Leave blank to disable.",
-            "env_variable": "SRCDS_BETAPASS",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "max:64",
-            "field_type": "text"
-        },
-        {
-            "name": "SteamCMD Login Username",
-            "description": "Set SteamCMD Login Username.",
-            "env_variable": "SRCDS_LOGIN",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|max:64|string",
-            "field_type": "text"
-        },
-        {
-            "name": "SteamCMD Login Password",
-            "description": "Set SteamCMD Login Password.",
-            "env_variable": "SRCDS_LOGIN_PASS",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|max:64|string",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
After the recent changes where valve allowed anonymous login, using an account or simply leaving the login variables blank would cause the installer to fail and then kick pterodactyl out of install mode. The container would restart and carry on the installation in front of the end user as usual, but any additional scripts wouldn't be run. 

This simply makes the installation script use the default anonymous variables and cleans up the login/beta variables that are no longer required.