### PR TITLE
Resolve #18, edit gameinfo.gi for MetaMod on server restart

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,21 @@
+name: "Shellcheck"
+permissions: {}
+on:
+  pull_request:
+    types: [opened, reopened]
+  push:
+    branches:
+      - main
+      - dev
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -s bash
+        with:
+          severity: error

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,3 +19,4 @@ jobs:
           SHELLCHECK_OPTS: -s bash
         with:
           severity: error
+          scandir: './docker'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # CS2 on Pterodactyl
 
-Docker image and Pterodactyl egg to prepare for upcoming CS (CS:GO/CS2) updates. The Docker image is based on the Valve provided SteamRT3 Sniper package, with the Pterodactyl egg featuring a few exposed variables such as Beta selection variables and allowing for skipping SteamCMD on launch (i.e, preventing updates). This should allow existing CSGO servers to easily stay on the opt-in CS:GO branch once CS2 releases.
+Docker image and Pterodactyl egg to run CS2 and CS:GO Servers on Valve's SteamRT3 platform. The Docker image is based on the Valve provided SteamRT3 Sniper package, with the Pterodactyl egg featuring a few exposed variables such as Beta selection variables and allowing for skipping SteamCMD on launch (i.e, preventing updates). This should allow existing CSGO servers to easily stay on the opt-in CS:GO branch (or any particular version of CS:GO) once CS2 releases.
 
 This setup is very similar to the stock Pterodactyl Source server setup, so things should be familiar once imported.
 
 The underlying Docker image is based on Valve's Steam Runtime 3 (Sniper), which should be able to run both CS:GO and CS2 without any issues. The image also can be rebuilt easily as soon as Valve updates their base SteamRT3 image, so we can stay on top of their updates without worrying too much about it. 
+
+The CS2 image also ensures the `gameinfo.gi` file is configured for MetaMod automatically on start-up. 
 
 ## How to use
 
@@ -20,6 +22,11 @@ The Docker image is hosted on the GitHub Container Registry. You can grab it fro
 ghcr.io/1zc/steamrt3-pterodactyl:latest
 ```
 
+The development branch contains upcoming changes that are currently being tested before being merged into main. If you'd like to use that image instead:
+```
+ghcr.io/1zc/steamrt3-pterodactyl:dev
+```
+
 Alternatively, you can find a full list of builds here: https://github.com/1zc/CS2-Pterodactyl/packages
 
 ## Frequent Issues
@@ -28,10 +35,12 @@ Alternatively, you can find a full list of builds here: https://github.com/1zc/C
   - Make sure you are using the correct IP address, and then try enabling "Force Outgoing IP" in the egg's configuration in your Pterodactyl Panel admin section.
   - `net_public_adr` doesn't work on CS2 at the time of writing this, so the above is a (hopefully) temporary workaround.
 - What operating systems can I run my CS2 server on?
-  - At the moment, it appears CS2 will run on the following without issues:
+  - At the moment, it appears CS2 will run on the following host operating systems without issues:
     - Ubuntu 20.04+
     - Debian 11+
     - *If you find any more, please open an issue and I'll add it to this list!*
+- My RCON doesn't work!
+  - Try setting your IP address in the launch command as `0.0.0.0` instead of the actual IP. 
 
 ## General Tips
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This setup is very similar to the stock Pterodactyl Source server setup, so thin
 
 The underlying Docker image is based on Valve's Steam Runtime 3 (Sniper), which should be able to run both CS:GO and CS2 without any issues. The image also can be rebuilt easily as soon as Valve updates their base SteamRT3 image, so we can stay on top of their updates without worrying too much about it. 
 
-The CS2 image also ensures the `gameinfo.gi` file is configured for MetaMod automatically on start-up. 
+The CS2 image also ensures the `gameinfo.gi` file is retained on server restart, which should allow configurations made for MetaMod to persist without issues.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This setup is very similar to the stock Pterodactyl Source server setup, so thin
 
 The underlying Docker image is based on Valve's Steam Runtime 3 (Sniper), which should be able to run both CS:GO and CS2 without any issues. The image also can be rebuilt easily as soon as Valve updates their base SteamRT3 image, so we can stay on top of their updates without worrying too much about it. 
 
-The CS2 image also ensures the `gameinfo.gi` file is retained on server restart, which should allow configurations made for MetaMod to persist without issues.
+The CS2 image also ensures the `gameinfo.gi` file is configured for MetaMod automatically on server restart, which should be convenient for modded servers. 
 
 ## How to use
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.source="https://github.com/1zc/cs2-pterodac
 # Prep OS
 RUN         mkdir -p /etc/sudoers.d && echo "%sudo ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/flatdeb && chmod 0440 /etc/sudoers.d/flatdeb
 ENV         DEBIAN_FRONTEND=noninteractive
+RUN         apt update && apt install -y iproute2 && apt-get clean
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -62,9 +62,9 @@ fi
 # Edit /home/container/game/csgo/gameinfo.gi to add MetaMod path
 # Credit: https://github.com/ghostcap-gaming/ACMRS-cs2-metamod-update-fix/blob/main/acmrs.sh
 GAMEINFO_FILE="/home/container/game/csgo/gameinfo.gi"
-GAMEINFO_ENTRY="            Game    csgo/addons/metamod"
+GAMEINFO_ENTRY="			Game	csgo/addons/metamod" 
 if [ -f "${GAMEINFO_FILE}" ]; then
-    if grep -Fxq "$GAMEINFO_ENTRY" "$GAMEINFO_FILE"; then
+    if grep -q "Game[[:blank:]]*csgo\/addons\/metamod" "$GAMEINFO_FILE"; then # match any whitespace
         echo "File gameinfo.gi already configured. No changes were made."
     else
         awk -v new_entry="$GAMEINFO_ENTRY" '
@@ -79,7 +79,7 @@ if [ -f "${GAMEINFO_FILE}" ]; then
             /Game_LowViolence/ { found=1; }
         ' "$GAMEINFO_FILE" > "$GAMEINFO_FILE.tmp" && mv "$GAMEINFO_FILE.tmp" "$GAMEINFO_FILE"
 
-        echo "The file ${GAMEINFO_FILE} has been configured successfully."
+        echo "The file ${GAMEINFO_FILE} has been configured for MetaMod successfully."
     fi
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,12 @@ sleep 1
 # Make internal Docker IP address available to processes.
 export INTERNAL_IP=`ip route get 1 | awk '{print $NF;exit}'`
 
+# Retain gameinfo.gi file - CS2 updates tend to reset this file to default, so we try to retain it.
+GAMEINFO_FILE="/home/container/game/csgo/gameinfo.gi"
+if [ -f "${GAMEINFO_FILE}" ]; then
+    mv "$GAMEINFO_FILE" "$GAMEINFO_FILE.tmp"
+fi
+
 # Update Source Server
 if [ ! -z ${SRCDS_APPID} ]; then
     if [ ${SRCDS_STOP_UPDATE} -eq 0 ]; then
@@ -59,33 +65,14 @@ if [ ! -z ${SRCDS_APPID} ]; then
     fi
 fi
 
+# Restore gameinfo.gi file
+if [ -f "${GAMEINFO_FILE}" ]; then
+    rm "$GAMEINFO_FILE" && mv "$GAMEINFO_FILE.tmp" "$GAMEINFO_FILE"
+fi
+
 # Replace Startup Variables
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
-
-# Edit /home/container/game/csgo/gameinfo.gi to add MetaMod path
-# Credit: https://github.com/ghostcap-gaming/ACMRS-cs2-metamod-update-fix/blob/main/acmrs.sh
-GAMEINFO_FILE="/home/container/game/csgo/gameinfo.gi"
-GAMEINFO_ENTRY="            Game    csgo/addons/metamod"
-if [ -f "${GAMEINFO_FILE}" ]; then
-    if grep -Fxq "$GAMEINFO_ENTRY" "$GAMEINFO_FILE"; then
-        echo "File gameinfo.gi already configured. No changes were made."
-    else
-        awk -v new_entry="$GAMEINFO_ENTRY" '
-            BEGIN { found=0; }
-            // {
-                if (found) {
-                    print new_entry;
-                    found=0;
-                }
-                print;
-            }
-            /Game_LowViolence/ { found=1; }
-        ' "$GAMEINFO_FILE" > "$GAMEINFO_FILE.tmp" && mv "$GAMEINFO_FILE.tmp" "$GAMEINFO_FILE"
-
-        echo "The file ${GAMEINFO_FILE} has been configured successfully."
-    fi
-fi
 
 # Run the Server
 eval ${MODIFIED_STARTUP}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,9 +66,7 @@ if [ ! -z ${SRCDS_APPID} ]; then
 fi
 
 # Restore gameinfo.gi file
-if [ -f "${GAMEINFO_FILE}" ]; then
-    rm "$GAMEINFO_FILE" && mv "$GAMEINFO_FILE.tmp" "$GAMEINFO_FILE"
-fi
+mv "$GAMEINFO_FILE.tmp" "$GAMEINFO_FILE"
 
 # Replace Startup Variables
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -63,5 +63,29 @@ fi
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
+# Edit /home/container/game/csgo/gameinfo.gi to add MetaMod path
+# Credit: https://github.com/ghostcap-gaming/ACMRS-cs2-metamod-update-fix/blob/main/acmrs.sh
+GAMEINFO_FILE="/home/container/game/csgo/gameinfo.gi"
+GAMEINFO_ENTRY="            Game    csgo/addons/metamod"
+if [ -f "${GAMEINFO_FILE}" ]; then
+    if grep -Fxq "$GAMEINFO_ENTRY" "$GAMEINFO_FILE"; then
+        echo "File gameinfo.gi already configured. No changes were made."
+    else
+        awk -v new_entry="$GAMEINFO_ENTRY" '
+            BEGIN { found=0; }
+            // {
+                if (found) {
+                    print new_entry;
+                    found=0;
+                }
+                print;
+            }
+            /Game_LowViolence/ { found=1; }
+        ' "$GAMEINFO_FILE" > "$GAMEINFO_FILE.tmp" && mv "$GAMEINFO_FILE.tmp" "$GAMEINFO_FILE"
+
+        echo "The file ${GAMEINFO_FILE} has been configured successfully."
+    fi
+fi
+
 # Run the Server
 eval ${MODIFIED_STARTUP}


### PR DESCRIPTION
- Fixes missing `iproute2` package - #18 
- The image will now edit `csgo/gameinfo.gi` before running SteamCMD on server restart. This will add an entry required for MetaMod automatically.

Leaving this here for now, will probably merge after a week or two of testing. 

To test this, switch your server to the `SteamRT3-Dev` Docker image in your server's startup settings. 
![image](https://github.com/1zc/CS2-Pterodactyl/assets/39123848/d97c92bb-1b1a-40cb-ba07-763cd4a025a8)
