### PR TITLE
Update steamclient.so in entrypoint - #44

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -61,6 +61,9 @@ if [ ! -z ${SRCDS_APPID} ]; then
 
         # echo "SteamCMD Launch: ${STEAMCMD}"
         eval ${STEAMCMD}
+        # Issue #44 - We can't symlink this, causes "File not found" errors. As a mitigation, copy over the updated binary on start.
+        cp -f ./steamcmd/linux32/steamclient.so ./.steam/sdk32/steamclient.so
+        cp -f ./steamcmd/linux64/steamclient.so ./.steam/sdk64/steamclient.so
     fi
 fi
 


### PR DESCRIPTION
Symlinking this binary on install seems to cause the server to fail reading the file. There likely is a better fix for this, but we need this to work to get servers w/ mods running again

Dev docker images will be updated shortly for testing